### PR TITLE
Adds missing i2s prescaler (I2SPR) register on some devices

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101x6.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101x6.h
@@ -392,6 +392,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101xb.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101xb.h
@@ -397,6 +397,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101xe.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101xe.h
@@ -514,6 +514,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101xg.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f101xg.h
@@ -526,6 +526,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f102x6.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f102x6.h
@@ -395,6 +395,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f102xb.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f102xb.h
@@ -400,6 +400,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f103x6.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f103x6.h
@@ -464,6 +464,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**

--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f103xb.h
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f103xb.h
@@ -469,6 +469,7 @@ typedef struct
   __IO uint32_t RXCRCR;
   __IO uint32_t TXCRCR;
   __IO uint32_t I2SCFGR;
+  __IO uint32_t I2SPR;
 } SPI_TypeDef;
 
 /**


### PR DESCRIPTION
Reference manual (RM0008) for STM32F101xx, STM32F102xx, STM32F103xx, STM32F105xx and STM32F107xx, p.750 shows that there is another register with offset 0x20 not yet included in SPI_TypeDef struct