### PR TITLE
Declare DMA handler State as volatile

### DIFF
--- a/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_hal_dma.h
+++ b/Drivers/STM32F1xx_HAL_Driver/Inc/stm32f1xx_hal_dma.h
@@ -116,7 +116,7 @@ typedef struct __DMA_HandleTypeDef
   
   HAL_LockTypeDef       Lock;                            /*!< DMA locking object                     */  
   
-  HAL_DMA_StateTypeDef  State;                           /*!< DMA transfer state                     */
+  __IO HAL_DMA_StateTypeDef  State;                           /*!< DMA transfer state                     */
   
   void                  *Parent;                                                      /*!< Parent object state                    */  
   


### PR DESCRIPTION
Not doing so causes issues when optimizations are enabled, the flag can change at any time by the DMA interrupt, but the compiler is unaware.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF1/blob/master/CONTRIBUTING.md) file.
