### PR TITLE
Typo in usbd_core.c

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
@@ -121,7 +121,7 @@ USBD_StatusTypeDef USBD_Init(USBD_HandleTypeDef *pdev,
 
 /**
 * @brief  USBD_DeInit
-*         Re-Initialize th device library
+*         Re-Initialize the device library
 * @param  pdev: device instance
 * @retval status: status
 */


### PR DESCRIPTION
In the function description of USBD_DeInit. There is a missing e.

Please refer to #52.
