### PR TITLE
startup_stm32f100xb.s: Small typo fix for SPI1_IRQHandler

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/gcc/startup_stm32f100xb.s
+++ b/Drivers/CMSIS/Device/ST/STM32F1xx/Source/Templates/gcc/startup_stm32f100xb.s
@@ -376,8 +376,8 @@ g_pfnVectors:
 
   .weak  SPI1_IRQHandler
   .thumb_set SPI1_IRQHandler,Default_Handler
-  
-  .weak  SPI1_IRQHandler
+
+  .weak  SPI2_IRQHandler
   .thumb_set SPI2_IRQHandler,Default_Handler
 
   .weak  USART1_IRQHandler


### PR DESCRIPTION
Fixes small typo that cause lot of confusion for users using CMSIS.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>
