### PR TITLE
stm32f1xx_hal_sram.c: Fix that SRAM state not set correctly

### DIFF
--- a/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_sram.c
+++ b/Drivers/STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_sram.c
@@ -215,7 +215,10 @@ HAL_StatusTypeDef HAL_SRAM_Init(SRAM_HandleTypeDef *hsram, FSMC_NORSRAM_TimingTy
   __FSMC_NORSRAM_ENABLE(hsram->Instance, hsram->Init.NSBank);
 
   /* Initialize the SRAM controller state */
-  hsram->State = HAL_SRAM_STATE_READY;
+  if (hsram->Init.WriteOperation == FSMC_WRITE_OPERATION_DISABLE)
+    hsram->State = HAL_SRAM_STATE_PROTECTED;
+  else
+    hsram->State = HAL_SRAM_STATE_READY;
 
   return HAL_OK;
 }


### PR DESCRIPTION
Fixes SRAM HAL code always set `State` to `HAL_SRAM_STATE_READY` even `WriteOperation` is not set.

## How does it make problem before?

If you initialize SRAM with `WriteOperation` disabled, It set `State` to `HAL_SRAM_STATE_READY`.
Then try to write SRAM falls into `HardFault_Handler`.
Even you can't enable `WriteOperation` via `HAL_SRAM_WriteOperation_Enable` function because the function tests `State == HAL_SRAM_STATE_PROTECTED`.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF1/blob/master/CONTRIBUTING.md) file.
